### PR TITLE
fixes request path for spring boot undertow http access errors.

### DIFF
--- a/logback-access-spring-boot-starter/pom.xml
+++ b/logback-access-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.rakugakibox.spring.boot</groupId>
     <artifactId>logback-access-spring-boot-starter</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>logback-access-spring-boot-starter</name>
     <description>Spring Boot Starter for Logback-access</description>

--- a/logback-access-spring-boot-starter/src/main/java/net/rakugakibox/spring/boot/logback/access/LogbackAccessContext.java
+++ b/logback-access-spring-boot-starter/src/main/java/net/rakugakibox/spring/boot/logback/access/LogbackAccessContext.java
@@ -15,6 +15,8 @@ import ch.qos.logback.core.joran.spi.JoranException;
 import ch.qos.logback.core.spi.FilterReply;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
+import net.rakugakibox.spring.boot.logback.access.undertow.UAbstractLogbackAccessEvent;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.env.Environment;
 import org.springframework.util.ResourceUtils;
@@ -155,6 +157,16 @@ public class LogbackAccessContext extends AccessContext {
      * @param event the Logback-access event.
      */
     public void emit(AbstractLogbackAccessEvent event) {
+        event.setUseServerPortInsteadOfLocalPort(logbackAccessProperties.isUseServerPortInsteadOfLocalPort());
+        if (getFilterChainDecision(event) != FilterReply.DENY) {
+            callAppenders(event);
+            applicationEventPublisher.publishEvent(new LogbackAccessAppendedEvent(this, event));
+        } else {
+            applicationEventPublisher.publishEvent(new LogbackAccessDeniedEvent(this, event));
+        }
+    }
+    
+    public void emit(UAbstractLogbackAccessEvent event) {
         event.setUseServerPortInsteadOfLocalPort(logbackAccessProperties.isUseServerPortInsteadOfLocalPort());
         if (getFilterChainDecision(event) != FilterReply.DENY) {
             callAppenders(event);

--- a/logback-access-spring-boot-starter/src/main/java/net/rakugakibox/spring/boot/logback/access/undertow/UAbstractLogbackAccessEvent.java
+++ b/logback-access-spring-boot-starter/src/main/java/net/rakugakibox/spring/boot/logback/access/undertow/UAbstractLogbackAccessEvent.java
@@ -1,0 +1,156 @@
+package net.rakugakibox.spring.boot.logback.access.undertow;
+
+import java.io.Serializable;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import ch.qos.logback.access.spi.AccessEvent;
+import ch.qos.logback.access.spi.ServerAdapter;
+import io.undertow.server.HttpServerExchange;
+import lombok.Getter;
+import lombok.Setter;
+import net.rakugakibox.spring.boot.logback.access.LogbackAccessSecurityAttributesSaveFilter;
+
+/**
+ * The base class of Logback-access events.
+ */
+public abstract class UAbstractLogbackAccessEvent extends UAccessEvent {
+
+    /**
+     * Whether to use the server port instead of the local port.
+     */
+    @Getter
+    @Setter
+    private boolean useServerPortInsteadOfLocalPort;
+
+    /**
+     * The local port.
+     */
+    private final LocalPort localPort = new LocalPort();
+
+    /**
+     * The remote user.
+     */
+    private final RemoteUser remoteUser = new RemoteUser();
+
+    /**
+     * Constructs an instance.
+     *
+     * @param request the HTTP request.
+     * @param response the HTTP response.
+     * @param adapter the server adapter.
+     */
+    public UAbstractLogbackAccessEvent(HttpServletRequest request, HttpServletResponse response, HttpServerExchange exchange, ServerAdapter adapter) {
+        super(request, response, exchange, adapter);
+        setThreadName(Thread.currentThread().getName());
+    }
+   
+
+    /** {@inheritDoc} */
+    @Override
+    public int getLocalPort() {
+        return localPort.get();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getRemoteUser() {
+        return remoteUser.get();
+    }
+
+    /**
+     * The base class that indicates the overridden attribute.
+     * The value is optional and it is lazily evaluated.
+     * If the evaluated value is present, caches it. Otherwise, returns the original value.
+     *
+     * @param <T> the type of value.
+     */
+    protected static abstract class AbstractOverridenAttribute<T extends Serializable> implements Serializable {
+
+        /**
+         * Whether was evaluated.
+         */
+        private boolean evaluated;
+
+        /**
+         * The evaluated value.
+         */
+        private T value;
+
+        /**
+         * Returns the value.
+         *
+         * @return the value.
+         */
+        public T get() {
+            if (!evaluated) {
+                value = evaluateValueToOverride().orElse(null);
+                evaluated = true;
+            }
+            return Optional.ofNullable(value).orElseGet(this::getOriginalValue);
+        }
+
+        /**
+         * Evaluates the value to override.
+         *
+         * @return the value to override.
+         */
+        protected abstract Optional<T> evaluateValueToOverride();
+
+        /**
+         * Returns the original value.
+         *
+         * @return the original value.
+         */
+        protected abstract T getOriginalValue();
+
+    }
+
+    /**
+     * The local port.
+     * Takes the server port if necessary.
+     */
+    private class LocalPort extends AbstractOverridenAttribute<Integer> {
+
+        /** {@inheritDoc} */
+        @Override
+        protected Optional<Integer> evaluateValueToOverride() {
+            return Optional.of(UAbstractLogbackAccessEvent.this)
+                    .filter(UAbstractLogbackAccessEvent::isUseServerPortInsteadOfLocalPort)
+                    .map(UAccessEvent::getRequest)
+                    .map(HttpServletRequest::getServerPort);
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        protected Integer getOriginalValue() {
+            return UAbstractLogbackAccessEvent.super.getLocalPort();
+        }
+
+    }
+
+    /**
+     * The remote user.
+     * Takes the remote user provided by Spring Security if necessary.
+     */
+    private class RemoteUser extends AbstractOverridenAttribute<String> {
+
+        /** {@inheritDoc} */
+        @Override
+        protected Optional<String> evaluateValueToOverride() {
+            return Optional.of(UAbstractLogbackAccessEvent.this)
+                    .map(UAccessEvent::getRequest)
+                    .map(request -> (String) request.getAttribute(
+                            LogbackAccessSecurityAttributesSaveFilter.REMOTE_USER_ATTRIBUTE_NAME));
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        protected String getOriginalValue() {
+            return UAbstractLogbackAccessEvent.super.getRemoteUser();
+        }
+
+    }
+
+}

--- a/logback-access-spring-boot-starter/src/main/java/net/rakugakibox/spring/boot/logback/access/undertow/UAccessEvent.java
+++ b/logback-access-spring-boot-starter/src/main/java/net/rakugakibox/spring/boot/logback/access/undertow/UAccessEvent.java
@@ -1,0 +1,620 @@
+package net.rakugakibox.spring.boot.logback.access.undertow;
+
+import ch.qos.logback.access.AccessConstants;
+import ch.qos.logback.access.pattern.AccessConverter;
+import ch.qos.logback.access.servlet.Util;
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.spi.ServerAdapter;
+import io.undertow.attribute.ExchangeAttribute;
+import io.undertow.attribute.ExchangeAttributes;
+import io.undertow.attribute.SubstituteEmptyWrapper;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
+import io.undertow.util.HeaderValues;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.springframework.boot.autoconfigure.web.ServerProperties.Undertow;
+import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.Serializable;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.Vector;
+
+// Contributors:  Joern Huxhorn (see also bug #110)
+
+/**
+ * The Access module's internal representation of logging events. When the
+ * logging component instance is called in the container to log then a
+ * <code>AccessEvent</code> instance is created. This instance is passed
+ * around to the different logback components.
+ *
+ * @author Ceki G&uuml;lc&uuml;
+ * @author S&eacute;bastien Pennec
+ */
+public class UAccessEvent implements Serializable, IAccessEvent {
+
+	private static final String[] NA_STRING_ARRAY = new String[] { NA };
+
+	private static final long serialVersionUID = 866718993618836343L;
+
+	private static final String EMPTY = "";
+
+	private transient final HttpServletRequest httpRequest;
+	private transient final HttpServletResponse httpResponse;
+	private transient final HttpServerExchange exchange;
+
+	String queryString;
+	String requestURI;
+	String requestURL;
+	String remoteHost;
+	String remoteUser;
+	String remoteAddr;
+	String threadName;
+	String protocol;
+	String method;
+	String serverName;
+	String requestContent;
+	String responseContent;
+	String sessionID;
+	long elapsedTime;
+
+	Map<String, String> requestHeaderMap;
+	Map<String, String[]> requestParameterMap;
+	Map<String, String> responseHeaderMap;
+	Map<String, Object> attributeMap;
+
+	long contentLength = SENTINEL;
+	int statusCode = SENTINEL;
+	int localPort = SENTINEL;
+
+	transient ServerAdapter serverAdapter;
+
+	/**
+	 * The number of milliseconds elapsed from 1/1/1970 until logging event was
+	 * created.
+	 */
+	private long timeStamp = 0;
+
+
+
+	public UAccessEvent(HttpServletRequest httpRequest, HttpServletResponse httpResponse, HttpServerExchange exchange, ServerAdapter adapter) {
+		this.httpRequest = httpRequest;
+		this.httpResponse = httpResponse;
+		this.timeStamp = System.currentTimeMillis();
+		this.serverAdapter = adapter;
+		this.elapsedTime = calculateElapsedTime();
+		this.exchange = exchange;
+	}
+
+	/**
+	 * Returns the underlying HttpServletRequest. After serialization the returned
+	 * value will be null.
+	 *
+	 * @return
+	 */
+	@Override
+	public HttpServletRequest getRequest() {
+		return httpRequest;
+	}
+
+	/**
+	 * Returns the underlying HttpServletResponse. After serialization the returned
+	 * value will be null.
+	 *
+	 * @return
+	 */
+	@Override
+	public HttpServletResponse getResponse() {
+		return httpResponse;
+	}
+
+	@Override
+	public long getTimeStamp() {
+		return timeStamp;
+	}
+
+	public void setTimeStamp(long timeStamp) {
+		if (this.timeStamp != 0) {
+			throw new IllegalStateException("timeStamp has been already set for this event.");
+		} else {
+			this.timeStamp = timeStamp;
+		}
+	}
+
+	/**
+	 * @param threadName The threadName to set.
+	 */
+	public void setThreadName(String threadName) {
+		this.threadName = threadName;
+	}
+
+	@Override
+	public String getThreadName() {
+		return threadName == null ? NA : threadName;
+	}
+
+	private transient ExchangeAttribute urltoken =   ExchangeAttributes.parser(Undertow.class.getClassLoader(), new SubstituteEmptyWrapper(NA)).parse("%U");
+	private transient ExchangeAttribute remoteHosttoken =   ExchangeAttributes.parser(Undertow.class.getClassLoader(), new SubstituteEmptyWrapper(NA)).parse("%h");
+	private transient ExchangeAttribute remoteUserToken =   ExchangeAttributes.parser(Undertow.class.getClassLoader(), new SubstituteEmptyWrapper(NA)).parse("%u");
+	private transient ExchangeAttribute remoteAddressToken =   ExchangeAttributes.parser(Undertow.class.getClassLoader(), new SubstituteEmptyWrapper(NA)).parse("%a");
+
+	@Override
+	public String getRequestURI() {
+		if (requestURI == null) {
+			if (exchange != null) {
+				requestURI = urltoken.readAttribute(exchange);
+			} else {
+				requestURI = NA;
+			}
+		}
+		return requestURI;
+	}
+
+	@Override
+	public String getQueryString() {
+		if (queryString == null) {
+
+			if (exchange != null) {
+				StringBuilder buf = new StringBuilder();
+				final String qStr = exchange.getQueryString();
+				if (!StringUtils.isEmpty(qStr)) {
+					buf.append(AccessConverter.QUESTION_CHAR);
+					buf.append(qStr);
+				}
+				queryString = buf.toString();
+			} else {
+				queryString = NA;
+			}
+		}
+		return queryString;
+	}
+
+	/**
+	 * The first line of the request.
+	 */
+	@Override
+	public String getRequestURL() {
+		if (requestURL == null) {
+			if (exchange != null) {
+				StringBuilder buf = new StringBuilder();
+				buf.append(exchange.getRequestMethod().toString());
+				buf.append(AccessConverter.SPACE_CHAR);
+				buf.append(getRequestURI());
+				buf.append(getQueryString());
+				buf.append(AccessConverter.SPACE_CHAR);
+				buf.append(exchange.getProtocol());
+				requestURL = buf.toString();
+
+			} else {
+				requestURL = NA;
+			}
+		}
+		return requestURL;
+	}
+
+	@Override
+	public String getRemoteHost() {
+		if (remoteHost == null) {
+			if (httpRequest != null) {
+                // the underlying implementation of HttpServletRequest will
+                // determine if remote lookup will be performed
+                remoteHost = remoteHosttoken.readAttribute(exchange);
+            } else {
+                remoteHost = NA;
+            }
+		}
+		return remoteHost;
+	}
+
+	@Override
+	public String getRemoteUser() {
+		if (remoteUser == null) {
+			if (httpRequest != null) {
+				remoteUser =  remoteUserToken.readAttribute(exchange);
+			} else {
+				remoteUser = NA;
+			}
+		}
+		return remoteUser;
+	}
+
+	@Override
+	public String getProtocol() {
+		if (protocol == null) {
+			if (exchange != null) {
+				protocol = exchange.getProtocol().toString();
+			} else {
+				protocol = NA;
+			}
+		}
+		return protocol;
+	}
+
+	@Override
+	public String getMethod() {
+		if (method == null) {
+			if (exchange != null) {
+				method = exchange.getRequestMethod().toString();
+			} else {
+				method = NA;
+			}
+		}
+		return method;
+	}
+
+	@Override
+	public String getSessionID() {
+		if (sessionID == null) {
+			if (httpRequest != null) {
+				final HttpSession session = httpRequest.getSession();
+				if (session != null) {
+					sessionID = session.getId();
+				}
+			} else {
+				sessionID = NA;
+			}
+		}
+		return sessionID;
+	}
+
+	@Override
+	public String getServerName() {
+		if (serverName == null) {
+			if (exchange != null) {
+				serverName = exchange.getHostName();
+			} else {
+				serverName = NA;
+			}
+		}
+		return serverName;
+	}
+
+	@Override
+	public String getRemoteAddr() {
+		 if (remoteAddr == null) {
+	            if (httpRequest != null) {
+	                remoteAddr = httpRequest.getRemoteAddr();
+	            } else {
+	                remoteAddr = NA;
+	            }
+	        }
+		return remoteAddr;
+	}
+
+	@Override
+	public String getRequestHeader(String key) {
+		String result = null;
+		key = key.toLowerCase();
+
+		if (requestHeaderMap == null) {
+			if (exchange != null) {
+				buildRequestHeaderMap();
+				result = requestHeaderMap.get(key);
+			}
+		} else {
+			result = requestHeaderMap.get(key);
+		}
+
+		if (result != null) {
+			return result;
+		} else {
+			return NA;
+		}
+	}
+
+	@Override
+	public Enumeration<String> getRequestHeaderNames() {
+		// post-serialization
+		if (httpRequest == null) {
+			Vector<String> list = new Vector<String>(getRequestHeaderMap().keySet());
+			return list.elements();
+		}
+		return httpRequest.getHeaderNames();
+	}
+
+	@Override
+	public Map<String, String> getRequestHeaderMap() {
+		if (requestHeaderMap == null) {
+			buildRequestHeaderMap();
+		}
+		return requestHeaderMap;
+	}
+
+	public void buildRequestHeaderMap() {
+		// according to RFC 2616 header names are case insensitive
+		// latest versions of Tomcat return header names in lower-case
+		requestHeaderMap = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+		HeaderMap map = exchange.getRequestHeaders();
+		if (map.size() == 0){
+			return;
+		}
+		for (HeaderValues headerValues : map) {
+			requestHeaderMap.put(headerValues.getHeaderName().toString(), map.get(headerValues.getHeaderName()).element());
+		}
+
+	}
+
+	public void buildRequestParameterMap() {
+		requestParameterMap = new HashMap<String, String[]>();
+		Enumeration<String> e = httpRequest.getParameterNames();
+		if (e == null) {
+			return;
+		}
+		while (e.hasMoreElements()) {
+			String key = e.nextElement();
+			requestParameterMap.put(key, httpRequest.getParameterValues(key));
+		}
+	}
+
+	@Override
+	public Map<String, String[]> getRequestParameterMap() {
+		if (requestParameterMap == null) {
+			buildRequestParameterMap();
+		}
+		return requestParameterMap;
+	}
+
+	@Override
+	public String getAttribute(String key) {
+		Object value = null;
+		if (attributeMap != null) {
+			// Event was prepared for deferred processing so we have a copy of attribute map and must use that copy
+			value = attributeMap.get(key);
+		} else if (httpRequest != null) {
+			// We have original request so take attribute from it
+			value = httpRequest.getAttribute(key);
+		}
+
+		return value != null ? value.toString() : NA;
+	}
+
+	private void copyAttributeMap() {
+
+		if (httpRequest == null) {
+			return;
+		}
+
+		// attributeMap has been copied already. See also LOGBACK-1189
+		if(attributeMap != null) {
+			return;
+		}
+
+		attributeMap = new HashMap<String, Object>();
+
+		Enumeration<String> names = httpRequest.getAttributeNames();
+		while (names.hasMoreElements()) {
+			String name = names.nextElement();
+
+			Object value = httpRequest.getAttribute(name);
+			if (shouldCopyAttribute(name, value)) {
+				attributeMap.put(name, value);
+			}
+		}
+	}
+
+	private boolean shouldCopyAttribute(String name, Object value) {
+		if (AccessConstants.LB_INPUT_BUFFER.equals(name) || AccessConstants.LB_OUTPUT_BUFFER.equals(name)) {
+			// Do not copy attributes used by logback internally - these are available via other getters anyway
+			return false;
+		} else if (value == null) {
+			// No reasons to copy nulls - Map.get() will return null for missing keys and the list of attribute
+			// names is not available through IAccessEvent
+			return false;
+		} else {
+			// Only copy what is serializable
+			return value instanceof Serializable;
+		}
+	}
+
+	@Override
+	public String[] getRequestParameter(String key) {
+		String[] value = null;
+
+		if(requestParameterMap != null) {
+			value = requestParameterMap.get(key);
+		} else if (httpRequest != null) {
+			value = httpRequest.getParameterValues(key);
+		}
+
+		return (value != null) ? value: NA_STRING_ARRAY;
+	}
+
+	@Override
+	public String getCookie(String key) {
+
+		if (httpRequest != null) {
+			Cookie[] cookieArray = httpRequest.getCookies();
+			if (cookieArray == null) {
+				return NA;
+			}
+
+			for (Cookie cookie : cookieArray) {
+				if (key.equals(cookie.getName())) {
+					return cookie.getValue();
+				}
+			}
+		}
+		return NA;
+	}
+
+	@Override
+	public long getContentLength() {
+		if (contentLength == SENTINEL) {
+			if (httpResponse != null) {
+				contentLength = serverAdapter.getContentLength();
+				return contentLength;
+			}
+		}
+		return contentLength;
+	}
+
+	public int getStatusCode() {
+		if (statusCode == SENTINEL) {
+			if (httpResponse != null) {
+				statusCode = serverAdapter.getStatusCode();
+			}
+		}
+		return statusCode;
+	}
+
+	public long getElapsedSeconds() {
+		return elapsedTime < 0 ? elapsedTime : elapsedTime / 1000;
+	}
+
+	public long getElapsedTime() {
+		return elapsedTime;
+	}
+
+	private long calculateElapsedTime() {
+		if (serverAdapter.getRequestTimestamp() < 0) {
+			return -1;
+		}
+		return getTimeStamp() - serverAdapter.getRequestTimestamp();
+	}
+
+	public String getRequestContent() {
+		if (requestContent != null) {
+			return requestContent;
+		}
+
+		if (Util.isFormUrlEncoded(httpRequest)) {
+			StringBuilder buf = new StringBuilder();
+
+			Enumeration<String> pramEnumeration = httpRequest.getParameterNames();
+
+			// example: id=1234&user=cgu
+			// number=1233&x=1
+			int count = 0;
+			try {
+				while (pramEnumeration.hasMoreElements()) {
+
+					String key = pramEnumeration.nextElement();
+					if (count++ != 0) {
+						buf.append("&");
+					}
+					buf.append(key);
+					buf.append("=");
+					String val = httpRequest.getParameter(key);
+					if (val != null) {
+						buf.append(val);
+					} else {
+						buf.append("");
+					}
+				}
+			} catch (Exception e) {
+				// FIXME Why is try/catch required?
+				e.printStackTrace();
+			}
+			requestContent = buf.toString();
+		} else {
+			// retrieve the byte array placed by TeeFilter
+			byte[] inputBuffer = (byte[]) httpRequest.getAttribute(AccessConstants.LB_INPUT_BUFFER);
+
+			if (inputBuffer != null) {
+				requestContent = new String(inputBuffer);
+			}
+
+			if (requestContent == null || requestContent.length() == 0) {
+				requestContent = EMPTY;
+			}
+		}
+
+		return requestContent;
+	}
+
+	public String getResponseContent() {
+		if (responseContent != null) {
+			return responseContent;
+		}
+
+		if (Util.isImageResponse(httpResponse)) {
+			responseContent = "[IMAGE CONTENTS SUPPRESSED]";
+		} else {
+
+			// retreive the byte array previously placed by TeeFilter
+			byte[] outputBuffer = (byte[]) httpRequest.getAttribute(AccessConstants.LB_OUTPUT_BUFFER);
+
+			if (outputBuffer != null) {
+				responseContent = new String(outputBuffer);
+			}
+			if (responseContent == null || responseContent.length() == 0) {
+				responseContent = EMPTY;
+			}
+		}
+
+		return responseContent;
+	}
+
+	public int getLocalPort() {
+		if (localPort == SENTINEL) {
+			if (httpRequest != null) {
+				localPort = httpRequest.getLocalPort();
+			}
+
+		}
+		return localPort;
+	}
+
+	public ServerAdapter getServerAdapter() {
+		return serverAdapter;
+	}
+
+	public String getResponseHeader(String key) {
+		buildResponseHeaderMap();
+		return responseHeaderMap.get(key);
+	}
+
+	void buildResponseHeaderMap() {
+		if (responseHeaderMap == null) {
+			responseHeaderMap = serverAdapter.buildResponseHeaderMap();
+		}
+	}
+
+	public Map<String, String> getResponseHeaderMap() {
+		buildResponseHeaderMap();
+		return responseHeaderMap;
+	}
+
+	public List<String> getResponseHeaderNameList() {
+		buildResponseHeaderMap();
+		return new ArrayList<String>(responseHeaderMap.keySet());
+	}
+
+	public void prepareForDeferredProcessing() {
+		getRequestHeaderMap();
+		getRequestParameterMap();
+		getResponseHeaderMap();
+		getLocalPort();
+		getMethod();
+		getProtocol();
+		getRemoteAddr();
+		getRemoteHost();
+		getRemoteUser();
+		getRequestURI();
+		getRequestURL();
+		getServerName();
+		getTimeStamp();
+		getElapsedTime();
+		getQueryString();
+
+		getStatusCode();
+		getContentLength();
+		getRequestContent();
+		getResponseContent();
+
+		copyAttributeMap();
+	}
+}

--- a/logback-access-spring-boot-starter/src/main/java/net/rakugakibox/spring/boot/logback/access/undertow/UndertowLogbackAccessEvent.java
+++ b/logback-access-spring-boot-starter/src/main/java/net/rakugakibox/spring/boot/logback/access/undertow/UndertowLogbackAccessEvent.java
@@ -10,12 +10,12 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.servlet.handlers.ServletRequestContext;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.HeaderValues;
-import net.rakugakibox.spring.boot.logback.access.AbstractLogbackAccessEvent;
+
 
 /**
  * The Logback-access event for Undertow.
  */
-public class UndertowLogbackAccessEvent extends AbstractLogbackAccessEvent {
+public class UndertowLogbackAccessEvent extends UAbstractLogbackAccessEvent {
 
     /**
      * Constructs an instance.
@@ -23,7 +23,7 @@ public class UndertowLogbackAccessEvent extends AbstractLogbackAccessEvent {
      * @param exchange the HTTP server exchange.
      */
     public UndertowLogbackAccessEvent(HttpServerExchange exchange) {
-        super(extractHttpServletRequest(exchange), extractHttpServletResponse(exchange), new ServerAdapter(exchange));
+        super(extractHttpServletRequest(exchange), extractHttpServletResponse(exchange), exchange, new ServerAdapter(exchange));
     }
 
     /**


### PR DESCRIPTION
This is a pretty hacky fix for undertow access logs that properly logs the request uri and request url with the initial path and not /error when spring boot ErrorMvcAutoConfiguration is in use.

this probably isnt the best way to resolve this issue, but it might help someone.