### PR TITLE
Support for spring boot > 2.2, undertow servlet factory renamed

### DIFF
--- a/logback-access-spring-boot-starter/pom.xml
+++ b/logback-access-spring-boot-starter/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.rakugakibox.spring.boot</groupId>
     <artifactId>logback-access-spring-boot-starter</artifactId>
-    <version>2.8.0-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>logback-access-spring-boot-starter</name>
     <description>Spring Boot Starter for Logback-access</description>
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.0.0.RELEASE</version>
+        <version>2.2.6.RELEASE</version>
     </parent>
 
     <organization>

--- a/logback-access-spring-boot-starter/src/main/java/net/rakugakibox/spring/boot/logback/access/undertow/UndertowLogbackAccessInstaller.java
+++ b/logback-access-spring-boot-starter/src/main/java/net/rakugakibox/spring/boot/logback/access/undertow/UndertowLogbackAccessInstaller.java
@@ -7,7 +7,7 @@ import io.undertow.servlet.api.DeploymentInfo;
 import lombok.extern.slf4j.Slf4j;
 import net.rakugakibox.spring.boot.logback.access.AbstractLogbackAccessInstaller;
 import net.rakugakibox.spring.boot.logback.access.LogbackAccessProperties;
-import org.springframework.boot.web.embedded.undertow.ConfigurableUndertowWebServerFactory;
+import org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.env.Environment;
 
@@ -16,7 +16,7 @@ import org.springframework.core.env.Environment;
  */
 @Slf4j
 public class UndertowLogbackAccessInstaller
-        extends AbstractLogbackAccessInstaller<ConfigurableUndertowWebServerFactory> {
+        extends AbstractLogbackAccessInstaller<UndertowServletWebServerFactory> {
 
     /**
      * Constructs an instance.
@@ -35,7 +35,7 @@ public class UndertowLogbackAccessInstaller
 
     /** {@inheritDoc} */
     @Override
-    protected void installLogbackAccess(ConfigurableUndertowWebServerFactory container) {
+    protected void installLogbackAccess(UndertowServletWebServerFactory container) {
         container.addBuilderCustomizers(this::enableRecordingRequestStartTime);
         container.addDeploymentInfoCustomizers(this::addUndertowHttpHandlerWrapper);
         log.debug("Installed Logback-access: container=[{}]", container);

--- a/logback-access-spring-boot-starter/src/test/java/net/rakugakibox/spring/boot/logback/access/AbstractServerPortUnusingTest.java
+++ b/logback-access-spring-boot-starter/src/test/java/net/rakugakibox/spring/boot/logback/access/AbstractServerPortUnusingTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootTest(
         value = {
                 "server.useForwardHeaders=true",
+                "server.forward-headers-strategy=FRAMEWORK",
                 "logback.access.config=classpath:logback-access.queue.xml",
                 "logback.access.useServerPortInsteadOfLocalPort=false",
         },

--- a/logback-access-spring-boot-starter/src/test/java/net/rakugakibox/spring/boot/logback/access/undertow/UndertowServerPortUnusingTest.java
+++ b/logback-access-spring-boot-starter/src/test/java/net/rakugakibox/spring/boot/logback/access/undertow/UndertowServerPortUnusingTest.java
@@ -32,8 +32,8 @@ public class UndertowServerPortUnusingTest extends AbstractServerPortUnusingTest
         LogbackAccessEventQueuingListener.appendedEventQueue.pop();
 
         assertThat(response).hasStatusCode(HttpStatus.OK);
-        assertThat(event).hasLocalPort(port);
-
+        //port is overridden permanently, can't do anyting with it right now
+//        assertThat(event).hasLocalPort(port);
     }
 
     /**

--- a/logback-access-spring-boot-starter/src/test/java/net/rakugakibox/spring/boot/logback/access/undertow/UndertowServerPortUnusingTest.java
+++ b/logback-access-spring-boot-starter/src/test/java/net/rakugakibox/spring/boot/logback/access/undertow/UndertowServerPortUnusingTest.java
@@ -32,8 +32,7 @@ public class UndertowServerPortUnusingTest extends AbstractServerPortUnusingTest
         LogbackAccessEventQueuingListener.appendedEventQueue.pop();
 
         assertThat(response).hasStatusCode(HttpStatus.OK);
-        //port is overridden permanently, can't do anyting with it right now
-//        assertThat(event).hasLocalPort(port);
+        assertThat(event).hasLocalPort(port);
     }
 
     /**


### PR DESCRIPTION
Since release of spring boot 2.2.* ConfigurableUndertowWebServerFactory renamed to UndertowServletWebServerFactory. And default behavior to X-Forwrarded-* headers changed as well.