### PR TITLE
fix: springProperty and springProfile no longer work in included files

### DIFF
--- a/src/main/kotlin/dev/akkinoc/spring/boot/logback/access/joran/LogbackAccessJoranConfigurator.kt
+++ b/src/main/kotlin/dev/akkinoc/spring/boot/logback/access/joran/LogbackAccessJoranConfigurator.kt
@@ -1,10 +1,12 @@
 package dev.akkinoc.spring.boot.logback.access.joran
 
 import ch.qos.logback.access.common.joran.JoranConfigurator
+import ch.qos.logback.core.joran.GenericXMLConfigurator
 import ch.qos.logback.core.joran.spi.ElementSelector
 import ch.qos.logback.core.joran.spi.RuleStore
 import ch.qos.logback.core.model.processor.DefaultProcessor
 import org.springframework.core.env.Environment
+import java.util.function.Supplier
 
 /**
  * The [JoranConfigurator] to support additional rules.
@@ -19,6 +21,15 @@ class LogbackAccessJoranConfigurator(private val environment: Environment) : Jor
         store.addRule(ElementSelector("configuration/springProperty")) { LogbackAccessJoranSpringPropertyAction() }
         store.addRule(ElementSelector("*/springProfile")) { LogbackAccessJoranSpringProfileAction() }
         store.addTransparentPathPart("springProfile")
+    }
+
+    override fun buildModelInterpretationContext() {
+        super.buildModelInterpretationContext()
+        modelInterpretationContext.configuratorSupplier = Supplier<GenericXMLConfigurator> {
+            LogbackAccessJoranConfigurator(environment).apply {
+                setContext(this.context)
+            }
+        }
     }
 
     override fun addModelHandlerAssociations(processor: DefaultProcessor) {

--- a/src/test/kotlin/dev/akkinoc/spring/boot/logback/access/joran/JoranSpringPropertyAsIncludeTest.kt
+++ b/src/test/kotlin/dev/akkinoc/spring/boot/logback/access/joran/JoranSpringPropertyAsIncludeTest.kt
@@ -1,0 +1,85 @@
+package dev.akkinoc.spring.boot.logback.access.joran
+
+import dev.akkinoc.spring.boot.logback.access.test.assertion.Assertions.assertLogbackAccessEventsEventually
+import dev.akkinoc.spring.boot.logback.access.test.type.JettyReactiveWebTest
+import dev.akkinoc.spring.boot.logback.access.test.type.JettyServletWebTest
+import dev.akkinoc.spring.boot.logback.access.test.type.TomcatReactiveWebTest
+import dev.akkinoc.spring.boot.logback.access.test.type.TomcatServletWebTest
+import dev.akkinoc.spring.boot.logback.access.test.type.UndertowReactiveWebTest
+import dev.akkinoc.spring.boot.logback.access.test.type.UndertowServletWebTest
+import io.kotest.matchers.collections.shouldHaveSingleElement
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.system.CapturedOutput
+import org.springframework.boot.test.system.OutputCaptureExtension
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.test.web.client.exchange
+import org.springframework.http.RequestEntity
+import org.springframework.test.context.TestPropertySource
+
+/**
+ * Tests the case where `<springProperty>` tags are used in the configuration file.
+ */
+@ExtendWith(OutputCaptureExtension::class)
+@TestPropertySource(
+    properties = [
+        "logback.access.config=classpath:logback-access-test-spring.property-as-include.xml",
+        "logback.access.test.console.pattern.prefix=>>>",
+        "logback.access.test.console.pattern.suffix=<<<",
+    ],
+)
+sealed class JoranSpringPropertyAsIncludeTest {
+
+    @Test
+    fun `Appends a Logback-access event according to the configuration file that contains springProperty tags`(
+        @Autowired rest: TestRestTemplate,
+        capture: CapturedOutput,
+    ) {
+        val request = RequestEntity.get("/mock-controller/text").build()
+        val response = rest.exchange<String>(request)
+        response.statusCode.value().shouldBe(200)
+        response.body.shouldBe("mock-text")
+        assertLogbackAccessEventsEventually {
+            capture.out.lines().shouldHaveSingleElement { it.startsWith(">>>") && it.endsWith("<<<") }
+        }
+    }
+
+}
+
+/**
+ * Tests the [JoranSpringPropertyAsIncludeTest] using the Tomcat servlet web server.
+ */
+@TomcatServletWebTest
+class TomcatServletWebJoranSpringPropertyAsIncludeTest : JoranSpringPropertyAsIncludeTest()
+
+/**
+ * Tests the [JoranSpringPropertyAsIncludeTest] using the Tomcat reactive web server.
+ */
+@TomcatReactiveWebTest
+class TomcatReactiveWebJoranSpringPropertyAsIncludeTest : JoranSpringPropertyAsIncludeTest()
+
+/**
+ * Tests the [JoranSpringPropertyAsIncludeTest] using the Jetty servlet web server.
+ */
+@JettyServletWebTest
+class JettyServletWebJoranSpringPropertyAsIncludeTest : JoranSpringPropertyAsIncludeTest()
+
+/**
+ * Tests the [JoranSpringPropertyAsIncludeTest] using the Jetty reactive web server.
+ */
+@JettyReactiveWebTest
+class JettyReactiveWebJoranSpringPropertyAsIncludeTest : JoranSpringPropertyAsIncludeTest()
+
+/**
+ * Tests the [JoranSpringPropertyAsIncludeTest] using the Undertow servlet web server.
+ */
+@UndertowServletWebTest
+class UndertowServletWebJoranSpringPropertyAsIncludeTest : JoranSpringPropertyAsIncludeTest()
+
+/**
+ * Tests the [JoranSpringPropertyAsIncludeTest] using the Undertow reactive web server.
+ */
+@UndertowReactiveWebTest
+class UndertowReactiveWebJoranSpringPropertyAsIncludeTest : JoranSpringPropertyAsIncludeTest()

--- a/src/test/resources/logback-access-test-spring.property-as-include.included.xml
+++ b/src/test/resources/logback-access-test-spring.property-as-include.included.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<included>
+    <springProperty
+            name="console_pattern_prefix"
+            source="logback.access.test.console.pattern.prefix"/>
+    <springProperty
+            name="console_pattern_body"
+            source="logback.access.test.console.pattern.body"
+            defaultValue="%h %l %u [%t] &quot;%r&quot; %s %b"/>
+    <springProperty
+            name="console_pattern_suffix"
+            source="logback.access.test.console.pattern.suffix"
+            defaultValue=";"/>
+    <springProperty name="ignored_source_is_blank" source=""/>
+    <springProperty name="ignored_source_is_missing"/>
+    <springProperty name="" source="logback.access.test.ignored.name-is-blank"/>
+    <springProperty source="logback.access.test.ignored.name-is-missing"/>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${console_pattern_prefix}${console_pattern_body}${console_pattern_suffix}</pattern>
+        </encoder>
+    </appender>
+    <appender-ref ref="console"/>
+</included>

--- a/src/test/resources/logback-access-test-spring.property-as-include.xml
+++ b/src/test/resources/logback-access-test-spring.property-as-include.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="logback-access-test-spring.property-as-include.included.xml"/>
+</configuration>


### PR DESCRIPTION
Fixes: https://github.com/akkinoc/logback-access-spring-boot-starter/issues/465