### PR TITLE
Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.0</version>
+        <version>3.4.2</version>
     </parent>
 
     <organization>
@@ -129,17 +129,17 @@
         <dependency>
             <groupId>ch.qos.logback.access</groupId>
             <artifactId>logback-access-common</artifactId>
-            <version>2.0.4</version>
+            <version>2.0.6</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback.access</groupId>
             <artifactId>logback-access-tomcat</artifactId>
-            <version>2.0.4</version>
+            <version>2.0.6</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback.access</groupId>
             <artifactId>logback-access-jetty12</artifactId>
-            <version>2.0.4</version>
+            <version>2.0.6</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Describe the changes

This pull request includes updates to the `pom.xml` file to upgrade the versions of several dependencies. The most important changes include updating the Spring Boot starter parent version and the versions of the Logback Access dependencies.

Dependency version upgrades:

* Updated Spring Boot starter parent version from `3.4.0` to `3.4.2`.
* Updated Logback Access dependencies versions from `2.0.4` to `2.0.6` for `logback-access-common`, `logback-access-tomcat`, and `logback-access-jetty12`.