### PR TITLE
Suppresses NullPointerException that occurs when the server name is missing

### DIFF
--- a/src/main/kotlin/dev/akkinoc/spring/boot/logback/access/LogbackAccessEvent.kt
+++ b/src/main/kotlin/dev/akkinoc/spring/boot/logback/access/LogbackAccessEvent.kt
@@ -59,7 +59,7 @@ class LogbackAccessEvent(private var source: LogbackAccessEventSource) : IAccess
     }
 
     override fun getServerName(): String {
-        return source.serverName
+        return source.serverName ?: NA
     }
 
     override fun getLocalPort(): Int {

--- a/src/main/kotlin/dev/akkinoc/spring/boot/logback/access/LogbackAccessEventSource.kt
+++ b/src/main/kotlin/dev/akkinoc/spring/boot/logback/access/LogbackAccessEventSource.kt
@@ -53,7 +53,7 @@ abstract class LogbackAccessEventSource {
     /**
      * The value of [IAccessEvent.getServerName].
      */
-    abstract val serverName: String
+    abstract val serverName: String?
 
     /**
      * The value of [IAccessEvent.getLocalPort].
@@ -185,7 +185,7 @@ abstract class LogbackAccessEventSource {
 
         override val threadName: String = source.threadName
 
-        override val serverName: String = source.serverName
+        override val serverName: String? = source.serverName
 
         override val localPort: Int = source.localPort
 

--- a/src/main/kotlin/dev/akkinoc/spring/boot/logback/access/jetty/LogbackAccessJettyEventSource.kt
+++ b/src/main/kotlin/dev/akkinoc/spring/boot/logback/access/jetty/LogbackAccessJettyEventSource.kt
@@ -59,7 +59,7 @@ class LogbackAccessJettyEventSource(
 
     override val threadName: String = currentThread().name
 
-    override val serverName: String by lazy(LazyThreadSafetyMode.NONE) {
+    override val serverName: String? by lazy(LazyThreadSafetyMode.NONE) {
         Request.getServerName(rawRequest)
     }
 

--- a/src/main/kotlin/dev/akkinoc/spring/boot/logback/access/tomcat/LogbackAccessTomcatEventSource.kt
+++ b/src/main/kotlin/dev/akkinoc/spring/boot/logback/access/tomcat/LogbackAccessTomcatEventSource.kt
@@ -55,7 +55,7 @@ class LogbackAccessTomcatEventSource(
 
     override val threadName: String = currentThread().name
 
-    override val serverName: String by lazy(LazyThreadSafetyMode.NONE) {
+    override val serverName: String? by lazy(LazyThreadSafetyMode.NONE) {
         request.getAccessLogAttribute(SERVER_NAME_ATTRIBUTE) ?: request.serverName
     }
 

--- a/src/main/kotlin/dev/akkinoc/spring/boot/logback/access/undertow/LogbackAccessUndertowEventSource.kt
+++ b/src/main/kotlin/dev/akkinoc/spring/boot/logback/access/undertow/LogbackAccessUndertowEventSource.kt
@@ -66,7 +66,7 @@ class LogbackAccessUndertowEventSource(
 
     override val threadName: String = currentThread().name
 
-    override val serverName: String by lazy(LazyThreadSafetyMode.NONE) {
+    override val serverName: String? by lazy(LazyThreadSafetyMode.NONE) {
         exchange.hostName
     }
 


### PR DESCRIPTION
## Describe the changes

Fix #96.
Suppresses NullPointerException that occurs when the server name is missing.
