### PR TITLE
Bump Kotlin from 2.2 to 2.3 to follow Spring Boot 4.1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java temurin-17
+java temurin-25

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Supports the following web servers:
 Depends on:
 
 * Java 17, 21, or 25
-* Kotlin 2.2
-* Spring Boot 4.0
+* Kotlin 2.3
+* Spring Boot 4.1
 * Logback-access 2.0
 
 ## Usage

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 java = "17"
 java-additional = "21,25"
-kotlin = "2.2.21"
+kotlin = "2.3.21"
 spring-boot = "4.1.0"
 detekt = "2.0.0-alpha.3"
 dokka = "2.2.0"


### PR DESCRIPTION
## Describe the changes

Spring Boot 4.1 ships with Kotlin 2.3, so bump Kotlin accordingly. Also update the development JDK in .tool-versions to Temurin 25 and refresh the dependency versions in README.md.
